### PR TITLE
Applying configuration adjustments

### DIFF
--- a/NSBTest/TestMessageHandler.cs
+++ b/NSBTest/TestMessageHandler.cs
@@ -1,8 +1,5 @@
 ﻿using System;
-using System.Data.SqlClient;
-using System.Threading;
 using System.Threading.Tasks;
-using System.Transactions;
 using Lib.Commands;
 using NServiceBus;
 
@@ -10,12 +7,11 @@ namespace NSBTest
 {
     public class TestMessageHandler : IHandleMessages<TestCommand>
     {
-        public Task Handle(TestCommand message, IMessageHandlerContext context)
+        public async Task Handle(TestCommand message, IMessageHandlerContext context)
         {
-            Console.WriteLine(DateTime.Now + " begin");
-            Thread.Sleep(TimeSpan.FromSeconds(35)); //actualy it's a call to some lib. in reality it works from 1 sec to 1.5 minutes.
-            Console.WriteLine(DateTime.Now + " end");
-            return Task.FromResult(0);
+            Console.WriteLine($"{DateTime.Now} begin ({message.Data})");
+            await Task.Delay(TimeSpan.FromSeconds(35)).ConfigureAwait(false); //actualy it's a call to some lib. in reality it works from 1 sec to 1.5 minutes.
+            Console.WriteLine($"{DateTime.Now} end ({message.Data})");
         }
     }
 }


### PR DESCRIPTION
Output of running with adjustments:
```
2018-02-23 15:40:35 begin (simple-2)
2018-02-23 15:40:35 begin (simple-0)
2018-02-23 15:40:35 begin (simple-3)
2018-02-23 15:40:35 begin (simple-6)
2018-02-23 15:40:35 begin (simple-1)
2018-02-23 15:41:10 end (simple-2)
2018-02-23 15:41:10 end (simple-0)
2018-02-23 15:41:10 end (simple-3)
2018-02-23 15:41:10 end (simple-6)
2018-02-23 15:41:10 begin (simple-10)
2018-02-23 15:41:10 end (simple-1)
2018-02-23 15:41:10 begin (simple-11)
2018-02-23 15:41:10 begin (simple-8)
2018-02-23 15:41:10 begin (simple-14)
2018-02-23 15:41:10 begin (simple-9)
2018-02-23 15:41:45 end (simple-10)
2018-02-23 15:41:45 end (simple-8)
2018-02-23 15:41:45 end (simple-11)
2018-02-23 15:41:45 begin (simple-18)
2018-02-23 15:41:45 end (simple-14)
2018-02-23 15:41:45 end (simple-9)
2018-02-23 15:41:45 begin (simple-16)
2018-02-23 15:41:45 begin (simple-19)
2018-02-23 15:41:45 begin (simple-17)
2018-02-23 15:42:20 end (simple-18)
2018-02-23 15:42:20 end (simple-16)
2018-02-23 15:42:20 end (simple-19)
2018-02-23 15:42:20 begin (simple-7)
2018-02-23 15:42:20 begin (simple-4)
2018-02-23 15:42:20 end (simple-17)
2018-02-23 15:42:20 begin (simple-5)
2018-02-23 15:42:35 begin (simple-15)
2018-02-23 15:42:35 begin (simple-12)
2018-02-23 15:42:35 begin (simple-13)
2018-02-23 15:42:55 end (simple-7)
2018-02-23 15:42:55 end (simple-4)
2018-02-23 15:42:55 end (simple-5)
2018-02-23 15:42:56 begin (simple-15)
2018-02-23 15:42:56 begin (simple-12)
2018-02-23 15:42:56 begin (simple-13)
2018-02-23 15:43:10 end (simple-15)
2018-02-23 15:43:10 end (simple-12)
2018-02-23 15:43:10 end (simple-13)
2018-02-23 15:43:31 end (simple-15)
2018-02-23 15:43:31 end (simple-12)
```

The endpoint has successfully processed all the messages

![image](https://user-images.githubusercontent.com/1309622/36620675-75c98e24-18b1-11e8-9a2b-c495d4204a7c.png)
